### PR TITLE
getting-help-on-irc: Mention relevant irc networks

### DIFF
--- a/src/content/docs/articles/getting-help-on-irc.mdx
+++ b/src/content/docs/articles/getting-help-on-irc.mdx
@@ -3,7 +3,7 @@ title: Getting help on IRC
 slug: getting-help-on-irc
 ---
 
-IRC (Internet Relay Chat) is a real-time chat where you can talk to other people from around the planet. Although many channels deal with smalltalk about the weather, girl-friends and politics there are IRC networks and channels that are dedicated to a piece of software or an operating system. irc.freenode.net for example exists to support open-source projects. In case you need urgent help or just don't want to use a mailing list then you are welcome on IRC. IRC has been there for ages and has evolved with the time. So it may appear like a hot tub of completely mad people at first. This article is meant to help you understand how to IRC works socially and how to get the most out of it.
+IRC (Internet Relay Chat) is a real-time chat where you can talk to other people from around the planet. Although many channels deal with smalltalk about the weather, girl-friends and politics there are IRC networks and channels that are dedicated to a piece of software or an operating system. irc.libera.chat and irc.oftc.net, for example, exist to support free and open-source projects. In case you need urgent help or just don't want to use a mailing list then you are welcome on IRC. IRC has been there for ages and has evolved with the time. So it may appear like a hot tub of completely mad people at first. This article is meant to help you understand how to IRC works socially and how to get the most out of it.
 
 # Don't ask to ask
 


### PR DESCRIPTION
The most important official IRC channels related to ISPmail are currently on Libera and OFTC. Both networks are also dedicated to free and open-source software.

Libera: #maria, #php (and more), #postgresql, #roundcube, #rspamd
OFTC: #debian, #dovecot

I couldn't find any reference on postfix.org, but #postfix, the most popular channel, is also on Libera.